### PR TITLE
Increase max line length

### DIFF
--- a/internal/ecslog/ecslog.go
+++ b/internal/ecslog/ecslog.go
@@ -18,7 +18,7 @@ import (
 // Version is the semver version of this tool.
 const Version = "0.0.0"
 
-const maxLineLen = 8192
+const maxLineLen = 16384
 
 // Renderer is the class used to drive ECS log rendering (aka pretty printing).
 type Renderer struct {


### PR DESCRIPTION
I just tried out ecslog. It works really well 👏 

The only thing was that I hit the line length limit of 8192 on a log with a big exception stack trace (the line was 8600 chars long). Doubling the default limit to 16k should be fine for most cases I think.

This is the offending log line:

```
{"@timestamp":"2021-03-16T09:44:03.352Z", "log.level":"ERROR", "message":"Application run failed", "ecs.version": "1.2.0","service.name":"PetClinicApplication","event.dataset":"PetClinicApplication.FILE","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.SpringApplication","error.type":"org.springframework.beans.factory.BeanCreationException","error.message":"Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Invocation of init method failed; nested exception is javax.persistence.PersistenceException: [PersistenceUnit: default] Unable to build Hibernate SessionFactory","error.stack_trace":"org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Invocation of init method failed; nested exception is javax.persistence.PersistenceException: [PersistenceUnit: default] Unable to build Hibernate SessionFactory\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1710)\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:583)\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:502)\n\tat org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:312)\n\tat org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:228)\n\tat org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:310)\n\tat org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200)\n\tat org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1085)\n\tat org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:858)\n\tat org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:549)\n\tat org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:140)\n\tat org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752)\n\tat org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:388)\n\tat org.springframework.boot.SpringApplication.run(SpringApplication.java:327)\n\tat org.springframework.boot.SpringApplication.run(SpringApplication.java:1246)\n\tat org.springframework.boot.SpringApplication.run(SpringApplication.java:1234)\n\tat org.springframework.samples.petclinic.PetClinicApplication.main(PetClinicApplication.java:34)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.springframework.boot.devtools.restart.RestartLauncher.run(RestartLauncher.java:49)\nCaused by: javax.persistence.PersistenceException: [PersistenceUnit: default] Unable to build Hibernate SessionFactory\n\tat org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.persistenceException(EntityManagerFactoryBuilderImpl.java:970)\n\tat org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:895)\n\tat org.springframework.orm.jpa.vendor.SpringHibernateJpaPersistenceProvider.createContainerEntityManagerFactory(SpringHibernateJpaPersistenceProvider.java:57)\n\tat org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.createNativeEntityManagerFactory(LocalContainerEntityManagerFactoryBean.java:365)\n\tat org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.buildNativeEntityManagerFactory(AbstractEntityManagerFactoryBean.java:388)\n\tat org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.afterPropertiesSet(AbstractEntityManagerFactoryBean.java:377)\n\tat org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.afterPropertiesSet(LocalContainerEntityManagerFactoryBean.java:341)\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1769)\n\tat org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1706)\n\t... 21 more\nCaused by: org.hibernate.MappingException: Could not get constructor for org.hibernate.persister.entity.SingleTableEntityPersister\n\tat org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:123)\n\tat org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:77)\n\tat org.hibernate.metamodel.internal.MetamodelImpl.initialize(MetamodelImpl.java:128)\n\tat org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:300)\n\tat org.hibernate.boot.internal.SessionFactoryBuilderImpl.build(SessionFactoryBuilderImpl.java:460)\n\tat org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:892)\n\t... 28 more\nCaused by: org.hibernate.HibernateException: Unable to instantiate default tuplizer [org.hibernate.tuple.entity.PojoEntityTuplizer]\n\tat org.hibernate.tuple.entity.EntityTuplizerFactory.constructTuplizer(EntityTuplizerFactory.java:91)\n\tat org.hibernate.tuple.entity.EntityTuplizerFactory.constructDefaultTuplizer(EntityTuplizerFactory.java:116)\n\tat org.hibernate.tuple.entity.EntityMetamodel.<init>(EntityMetamodel.java:385)\n\tat org.hibernate.persister.entity.AbstractEntityPersister.<init>(AbstractEntityPersister.java:519)\n\tat org.hibernate.persister.entity.SingleTableEntityPersister.<init>(SingleTableEntityPersister.java:124)\n\tat java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)\n\tat java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)\n\tat org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:96)\n\t... 33 more\nCaused by: java.lang.reflect.InvocationTargetException\n\tat java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)\n\tat java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)\n\tat org.hibernate.tuple.entity.EntityTuplizerFactory.constructTuplizer(EntityTuplizerFactory.java:88)\n\t... 42 more\nCaused by: java.lang.NullPointerException\n\tat javassist.util.proxy.SecurityActions.setAccessible(SecurityActions.java:103)\n\tat javassist.util.proxy.DefineClassHelper.toClass3(DefineClassHelper.java:151)\n\tat javassist.util.proxy.DefineClassHelper.toClass2(DefineClassHelper.java:134)\n\tat javassist.util.proxy.DefineClassHelper.toClass(DefineClassHelper.java:95)\n\tat javassist.util.proxy.FactoryHelper.toClass(FactoryHelper.java:131)\n\tat javassist.util.proxy.ProxyFactory.createClass3(ProxyFactory.java:530)\n\tat javassist.util.proxy.ProxyFactory.createClass2(ProxyFactory.java:515)\n\tat javassist.util.proxy.ProxyFactory.createClass1(ProxyFactory.java:451)\n\tat javassist.util.proxy.ProxyFactory.createClass(ProxyFactory.java:422)\n\tat org.hibernate.proxy.pojo.javassist.JavassistProxyFactory.postInstantiate(JavassistProxyFactory.java:75)\n\tat org.hibernate.tuple.entity.PojoEntityTuplizer.buildProxyFactory(PojoEntityTuplizer.java:162)\n\tat org.hibernate.tuple.entity.AbstractEntityTuplizer.<init>(AbstractEntityTuplizer.java:156)\n\tat org.hibernate.tuple.entity.PojoEntityTuplizer.<init>(PojoEntityTuplizer.java:58)\n\t... 47 more\n"}
```